### PR TITLE
Preference factors in form of inconvenience costs and SW together.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: moinput
 Type: Package
 Title: Model Operations Input Data Library
-Version: 9.314.0
+Version: 9.314.1
 Date: 2020-02-26
 Author: Lavinia Baumstark, Anastasis Giannousakis, Jan Philipp Dietrich, Ulrich
     Kreidenweis, Benjamin Bodirsky, Isabelle Weindl, Mishko Stevanovic, Xiaoxi Wang, Ewerton Araujo, Florian Humpenoeder, Stephen Wirth, Kristine Karstens, Abhijeet Mishra
@@ -57,7 +57,7 @@ License: LGPL-3 | file LICENSE
 LazyData: no
 Encoding: UTF-8
 RoxygenNote: 7.0.2
-ValidationKey: 1706138520
+ValidationKey: 1706156838
 Suggests: knitr,
     rmarkdown,
 	ggplot2

--- a/R/calcEDGETransport.R
+++ b/R/calcEDGETransport.R
@@ -72,9 +72,9 @@ calcEDGETransport <- function(subtype = "logit_exponent") {
            unit = "[-]"
            description = "Share weight, a dimensionless parameter reflecting consumer preferences."
          },
-         "inconv" = {
+         "pref" = {
            weight = NULL
-           unit = "Passenger transport: [1990$/pkm]; freight transport: [1990$/tkm]"
+           unit = "LDVs 4wheelers: inconvenience cost [1990$/pkm]; all other modes: [-] share weight, a dimensionless parameter reflecting consumer preferences"
            description = "Inconvenience cost reflecting availability of infrastructure"
          },
          "price_nonmot" = {

--- a/R/convertEDGETransport.R
+++ b/R/convertEDGETransport.R
@@ -1,4 +1,4 @@
-#' Convert IEA
+#' Convert EDGEtransport
 #' 
 #' Ship EDGETransport data through, as already on ISO level
 #' 
@@ -10,7 +10,7 @@
 
 convertEDGETransport = function(x, subtype) {
   
-  if (subtype %in% c("esCapCost", "fe_demand_tech", "fe2es", "UCD_NEC_iso", "harmonized_intensities", "value_time", "SW", "inconv")) {
+  if (subtype %in% c("esCapCost", "fe_demand_tech", "fe2es", "UCD_NEC_iso", "harmonized_intensities", "value_time", "SW", "pref")) {
     ## magpie object creates NA whenever the initial dt is not symmetric (entry absent in ISO1 but exists in ISO2)
     ## the NAs are therefore converted to 0
     x[is.na(x)] <- 0

--- a/R/fullREMIND.R
+++ b/R/fullREMIND.R
@@ -149,7 +149,7 @@ fullREMIND <- function(rev=0) {
   
   #--------------- EDGE Transport ---------------------------------------------------------------------
   sapply(c("value_time", "harmonized_intensities", "price_nonmot",
-           "SW", "inconv", "UCD_NEC_iso", "logit_exponent"),
+           "SW", "pref", "UCD_NEC_iso", "logit_exponent"),
          function(stype){
            print(sprintf("Loading %s", stype))
            suppressWarnings(calcOutput("EDGETransport", subtype=stype,


### PR DESCRIPTION
Preference for transport modes/powertrains is expressed via inconvenience costs for 4wheelers, and share-weights otherwise. 

- This change depend on a change in the library `edgeTrpLib` so an update of this package is required. 
- The data generated with the updated function can be loaded via the `scripts/iterative/EDGE_transport.R` script in REMIND, which needs as well to be updated.
- Data preparation for moinput relies on the package `EDGETransport`, see https://gitlab.pik-potsdam.de/REMIND/EDGE_transport