### PR TITLE
Update SDP industry demand trajectories

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: moinput
 Type: Package
 Title: Model Operations Input Data Library
-Version: 9.344.4
-Date: 2020-04-30
+Version: 9.344.5
+Date: 2020-05-27
 Author: Lavinia Baumstark, Anastasis Giannousakis, Jan Philipp Dietrich, Ulrich
     Kreidenweis, Benjamin Bodirsky, Isabelle Weindl, Mishko Stevanovic, Xiaoxi Wang, Ewerton Araujo, Florian Humpenoeder, Stephen Wirth, Kristine Karstens, Abhijeet Mishra
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
@@ -58,7 +58,7 @@ License: LGPL-3 | file LICENSE
 LazyData: no
 Encoding: UTF-8
 RoxygenNote: 7.1.0
-ValidationKey: 1717687608
+ValidationKey: 1720229005
 Suggests: knitr,
     testthat,
     rmarkdown,


### PR DESCRIPTION
Slightly changing the way the *correction factor* for industry FE demands is calculated, i.e., the factor that is used on SSP1/SSP2 industry FE demands to get SDP demands.

The factor represents the relative changes, to get the absolute factor, the cumulative product is calculated in the source code.

The new factor aims to provide additional slack for poor countries to build infrastructure. Plotted in the time domain for all regions:

![Screenshot from 2020-05-27 15-00-52](https://user-images.githubusercontent.com/6737625/83021834-e2a8b800-a02a-11ea-8d74-212d0bf1f2b5.png)
